### PR TITLE
Updating parameters to echo browse_sort_links

### DIFF
--- a/views/admin/browse/by-stat.php
+++ b/views/admin/browse/by-stat.php
@@ -25,7 +25,7 @@ echo common('stats-nav');
             $browseHeadings[__('Dedicated Record')] = null;
             $browseHeadings[__('Record Type')] = 'record_type';
             $browseHeadings[__('Date')] = 'modified';
-            echo browse_sort_links($browseHeadings, array('link_tag' => 'th scope="col"', 'list_tag' => ''));
+            echo browse_sort_links($browseHeadings, array('link_tag' => 'th', 'link_attr' => array('scope' => 'col'), 'list_tag' => ''));
             ?>
         </tr>
     </thead>


### PR DESCRIPTION
With the current setting, the scope=col is appended to the closing tag, resulting in a malformed html (```</th scope="col">```), this patch should fix the issue.