### PR TITLE
Options for excluding bots from being harvested

### DIFF
--- a/StatsPlugin.php
+++ b/StatsPlugin.php
@@ -76,6 +76,7 @@ class StatsPlugin extends Omeka_Plugin_AbstractPlugin
         'stats_display_by_hooks' => 'a:10:{i:0;s:15:"admin_dashboard";i:1;s:24:"admin_items_show_sidebar";i:2;s:30:"admin_collections_show_sidebar";i:3;s:24:"admin_files_show_sidebar";i:4;s:30:"admin_items_browse_simple_each";i:5;s:32:"admin_items_browse_detailed_each";i:6;s:17:"public_items_show";i:7;s:24:"public_items_browse_each";i:8;s:23:"public_collections_show";i:9;s:30:"public_collections_browse_each";}',
         // Privacy settings.
         'stats_privacy' => 'hashed',
+        'stats_excludebots' => 0
     );
 
     /**

--- a/StatsPlugin.php
+++ b/StatsPlugin.php
@@ -784,7 +784,11 @@ class StatsPlugin extends Omeka_Plugin_AbstractPlugin
     {
         $hit = new Hit;
         $hit->setCurrentHit();
-        $hit->save();
+
+        // The hit is saved only if if stats_excludebots setting is set and the request is from a bot
+        if ( (!get_option("stats_excludebots")) || (!$hit->isBot()) ) {
+            $hit->save();
+        }
     }
 
     /**

--- a/models/Hit.php
+++ b/models/Hit.php
@@ -123,6 +123,17 @@ class Hit extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inter
     }
 
     /**
+     * Determine whether or not the hit is from a bot/webcrawler
+     *
+     * @return boolean True if hit is from a bot, otherwise False
+     */
+    public function isBot()
+    {
+        return (strpos($this->user_agent, 'bot') !== false) ;
+    }
+
+
+    /**
      * Determine whether or not the hit is a direct download.
      *
      * @return boolean True if hit has a record, even deleted.

--- a/models/Hit.php
+++ b/models/Hit.php
@@ -135,6 +135,7 @@ class Hit extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inter
 						(strpos($this->user_agent, 'bot') !== false) ||
 						(strpos($this->user_agent, 'slurp') !== false) ||
 						(strpos($this->user_agent, 'crawler') !== false) ||
+						(strpos($this->user_agent, 'check_http') !== false) ||
 						(strpos($this->user_agent, 'spider') !== false)
 					);
     }

--- a/models/Hit.php
+++ b/models/Hit.php
@@ -129,7 +129,14 @@ class Hit extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inter
      */
     public function isBot()
     {
-        return (strpos($this->user_agent, 'bot') !== false) ;
+			print "<!-- UA : ".$this->user_agent." -->";
+        return 
+					(
+						(strpos($this->user_agent, 'bot') !== false) ||
+						(strpos($this->user_agent, 'slurp') !== false) ||
+						(strpos($this->user_agent, 'crawler') !== false) ||
+						(strpos($this->user_agent, 'spider') !== false)
+					);
     }
 
 

--- a/views/admin/plugins/stats-config-form.php
+++ b/views/admin/plugins/stats-config-form.php
@@ -200,3 +200,21 @@
         </div>
     </div>
 </fieldset>
+<fieldset id="fieldset-stats-misc"><legend><?php echo __('Misc'); ?></legend>
+    <div class="field">
+        <div class="two columns alpha">
+            <?php echo $this->formLabel('stats_excludebots', __('Exclude crawlers/bots')); ?>
+        </div>
+        <div class="inputs five columns omega">
+
+            <?php 
+                echo "\n".$this->formCheckbox('stats_excludebots', true,
+                            array('checked' => (boolean) get_option("stats_excludebots")));
+            ?>
+            <p class="explanation">
+                <?php echo __('By checking this box, all hits which user agent contains the term bot will be excluded.');
+                ?>
+            </p>
+        </div>
+    </div>
+</fieldset>


### PR DESCRIPTION
Following the issue https://github.com/Daniel-KM/Stats/issues/3 a small patch to the plugin to allow user to not store stats when the user_agent contains the string "bot", which should exclude a lot of the data coming from bots/crawlers. 

That's not the best solution as we will always miss bots but at least the figures will be less misleading.