### PR TITLE
Optimize count queries on summary page

### DIFF
--- a/controllers/SummaryController.php
+++ b/controllers/SummaryController.php
@@ -114,11 +114,10 @@ class Stats_SummaryController extends Omeka_Controller_AbstractActionController
 
         $result = array();
         if (is_admin_theme()) {
-            $result['total'] = $tableHit->count($params);
-            $params['user_status'] = 'hits_anonymous';
-            $result['anonymous'] = $tableHit->count($params);
-            $params['user_status'] = 'hits_identified';
-            $result['identified'] = $tableHit->count($params);
+            $counts = $tableHit->getCountsByUserStatus($params);
+            $result['anonymous'] = $counts['hits_anonymous'];
+            $result['identified'] = $counts['hits_identified'];
+            $result['total'] = $result['anonymous'] + $result['identified'];
         }
         else {
             $params['user_status'] = $userStatus;

--- a/models/Table/Hit.php
+++ b/models/Table/Hit.php
@@ -608,6 +608,31 @@ class Table_Hit extends Omeka_Db_Table
         }
     }
 
+    public function getCountsByUserStatus($params = array())
+    {
+        $select = $this->getSelectForCount($params);
+
+        $user_status = new Zend_Db_Expr('CASE user_id WHEN 0 THEN "hits_anonymous" ELSE "hits_identified" END');
+
+        $select->reset(Zend_Db_Select::COLUMNS);
+        $select->columns(array(
+            'count' => 'COUNT(*)',
+            'user_status' => $user_status,
+        ));
+        $select->group($user_status);
+
+        $results = $this->_db->query($select, array())->fetchAll();
+        $counts = array(
+            'hits_anonymous' => 0,
+            'hits_identified' => 0,
+        );
+        foreach ($results as $result) {
+            $counts[$result['user_status']] = $result['count'];
+        }
+
+        return $counts;
+    }
+
     /**
      * Get and parse sorting parameters (may be multiples).
      *


### PR DESCRIPTION
On summary page, _statsPeriod is called 11 times and executes 3 SQL
queries per call. Those queries are slow with a huge number of entries
in hits table. The same result can be achieved with 1 query per call.

Times I get with 2.8M rows in hits table:
  Without patch: ~48s
  With patch: ~18s